### PR TITLE
Migrate way to import / import using an alias instead of relative paths

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,6 +6,7 @@ module.exports = {
     author: `@davidsonfellipe`,
   },
   plugins: [
+    `gatsby-alias-imports`,
     `gatsby-plugin-styled-components`,
     `gatsby-plugin-react-helmet`,
     {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dependencies": {
         "babel-plugin-styled-components": "^1.10.7",
         "gatsby": "^2.19.45",
+        "gatsby-alias-imports": "^1.0.4",
         "gatsby-cli": "^2.11.10",
         "gatsby-image": "^2.2.44",
         "gatsby-plugin-google-analytics": "^2.2.2",

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -2,9 +2,9 @@ import React from 'react'
 import Link from 'gatsby-link'
 import styled from 'styled-components'
 
-import Section from './Section'
-import { screen } from '../styles/screen'
-import { font } from '../styles/theme'
+import Section from 'components/Section'
+import { screen } from 'styles/screen'
+import { font } from 'styles/theme'
 
 const Logo = styled.span`
   display: inline-block;

--- a/src/components/Hello.js
+++ b/src/components/Hello.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { screen } from '../styles/screen'
-import { font } from '../styles/theme'
+import { screen } from 'styles/screen'
+import { font } from 'styles/theme'
 
 const Name = styled.h1`
   font-family: ${font.title};

--- a/src/components/ItemDate.js
+++ b/src/components/ItemDate.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-import { screen } from '../styles/screen'
+import { screen } from 'styles/screen'
 
 const ItemDate = styled.span`
   font-size: 20px;

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -12,11 +12,11 @@ import './layout.css'
 
 import styled from 'styled-components'
 
-import { screen } from '../styles/screen'
-import { font } from '../styles/theme'
+import { screen } from 'styles/screen'
+import { font } from 'styles/theme'
 
-import Header from './Header'
-import Footer from './Footer'
+import Header from 'components/Header'
+import Footer from 'components/Footer'
 
 const Wrapper = styled.div`
   font-family: ${font.text};

--- a/src/components/Opening.js
+++ b/src/components/Opening.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import Text from './Text'
-import { screen } from '../styles/screen'
+import Text from 'components/Text'
+import { screen } from 'styles/screen'
 
 const Section = styled.section`
   display: inline-block;

--- a/src/components/PostContent.js
+++ b/src/components/PostContent.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 
-import { font } from '../styles/theme'
-import { screen } from '../styles/screen'
+import { font } from 'styles/theme'
+import { screen } from 'styles/screen'
 
 const PostWrapper = styled.div`
   font-size: 20px;

--- a/src/components/PostFooter.js
+++ b/src/components/PostFooter.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { screen } from '../styles/screen'
-import profile from '../images/profile.jpg'
+import { screen } from 'styles/screen'
+import profile from 'images/profile.jpg'
 
 const Footer = styled.h1`
   margin: 75px 0 25px 0;

--- a/src/components/PostLink.js
+++ b/src/components/PostLink.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import Link from '../components/Link'
-import ItemDate from '../components/ItemDate'
+import Link from 'components/Link'
+import ItemDate from 'components/ItemDate'
 
-import { screen } from '../styles/screen'
+import { screen } from 'styles/screen'
 
 const Date = styled(ItemDate)`
   display: none;

--- a/src/components/Section.js
+++ b/src/components/Section.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-import { screen } from '../styles/screen'
+import { screen } from 'styles/screen'
 
 const Section = styled.div`
   max-width: ${screen.max};

--- a/src/components/Title.js
+++ b/src/components/Title.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 
-import { font } from '../styles/theme'
-import { screen } from '../styles/screen'
+import { font } from 'styles/theme'
+import { screen } from 'styles/screen'
 
 const Title = styled.h1`
   color: #333;

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
-import Layout from '../components/Layout'
-import SEO from '../components/SEO'
+import Layout from 'components/Layout'
+import SEO from 'components/SEO'
 
 const NotFoundPage = () => (
   <Layout>

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import { graphql } from 'gatsby'
 
-import PostLink from '../components/PostLink'
-import Title from '../components/Title'
-import Section from '../components/Section'
-import Layout from '../components/Layout'
-import SEO from '../components/SEO'
+import PostLink from 'components/PostLink'
+import Title from 'components/Title'
+import Section from 'components/Section'
+import Layout from 'components/Layout'
+import SEO from 'components/SEO'
 
 const BlogPage = ({
   data: {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,9 +1,9 @@
 import React from 'react'
 
-import Layout from '../components/Layout'
-import SEO from '../components/SEO'
-import Hello from '../components/Hello'
-import Opening from '../components/Opening'
+import Layout from 'components/Layout'
+import SEO from 'components/SEO'
+import Hello from 'components/Hello'
+import Opening from 'components/Opening'
 
 const IndexPage = () => (
   <Layout>

--- a/src/pages/talks.js
+++ b/src/pages/talks.js
@@ -1,11 +1,11 @@
 import React from 'react'
 
-import Title from '../components/Title'
-import Section from '../components/Section'
-import Link from '../components/Link'
-import ItemDate from '../components/ItemDate'
-import Layout from '../components/Layout'
-import SEO from '../components/SEO'
+import Title from 'components/Title'
+import Section from 'components/Section'
+import Link from 'components/Link'
+import ItemDate from 'components/ItemDate'
+import Layout from 'components/Layout'
+import SEO from 'components/SEO'
 
 const TalksPage = () => (
   <Layout>

--- a/src/templates/blogTemplate.js
+++ b/src/templates/blogTemplate.js
@@ -1,14 +1,14 @@
 import React from 'react'
 import { graphql } from 'gatsby'
 
-import Title from '../components/Title'
-import Section from '../components/Section'
-import Layout from '../components/Layout'
-import SEO from '../components/SEO'
-import PostContent from '../components/PostContent'
-import PostDate from '../components/PostDate'
-import PostFooter from '../components/PostFooter'
-import TimeToRead from '../components/TimeToRead'
+import Title from 'components/Title'
+import Section from 'components/Section'
+import Layout from 'components/Layout'
+import SEO from 'components/SEO'
+import PostContent from 'components/PostContent'
+import PostDate from 'components/PostDate'
+import PostFooter from 'components/PostFooter'
+import TimeToRead from 'components/TimeToRead'
 
 export default function Template({
   data,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6117,6 +6117,11 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+gatsby-alias-imports@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/gatsby-alias-imports/-/gatsby-alias-imports-1.0.4.tgz#09177ad05aa24f321813e713de5fd7aa2b8ec5b1"
+  integrity sha512-6ov7Qd/cKdEaqrABlPUNDXWHGn8HJpU/TGm0/htBAi4nSfFJWq6EEw9apzWHfR8IoVwjHExlX5wD7Y4qKjMV0w==
+
 gatsby-cli@^2.10.11:
   version "2.10.11"
   resolved "https://registry.yarnpkg.com/gatsby-cli/-/gatsby-cli-2.10.11.tgz#4a10425c2dbd5eb551c51315f778e24c6b313e1a"


### PR DESCRIPTION
## Types of changes
- Refactor

## Description of changes
Migrate way to import / import using an alias instead of relative paths

```javascript
import { screen } from 'styles/screen'
import profile from 'images/profile.jpg'
```

Instead of

```javascript
import { screen } from '../styles/screen'
import profile from '../images/profile.jpg'
```

- [x] Install gatsby-alias-imports
- [x] Migrate all imports