### PR TITLE
fix(talks): migrate urls to https in jqueryfn talk

### DIFF
--- a/src/legacy/slides/jqueryfn/index.html
+++ b/src/legacy/slides/jqueryfn/index.html
@@ -114,7 +114,7 @@
           		    <img src="/slides/jqueryfn/assets/img/iceberg_2.jpg" width="1024" height="768" alt="Iceberg">
           		  </p>
           		  <div class='source white'>
-          		    http://xstudo.files.wordpress.com/2010/10/iceberg_2.jpg
+          		    https://xstudo.files.wordpress.com/2010/10/iceberg_2.jpg
           		  </div>
           		</article>
 
@@ -564,7 +564,7 @@ $("body").bgChange({bg: "#00f"}); //azul
             <article>
               <h3>Onde eu posso revisar meu código</h3>
               <ul>
-                <li class="black">JSmentors | http://groups.google.com/group/jsmentors</li>
+                <li class="black">JSmentors | https://groups.google.com/g/jsmentors?pli=1</li>
                 <li class="black">Douglas Crockford |
                 https://www.jslint.com/
                 </li>
@@ -585,13 +585,13 @@ $("body").bgChange({bg: "#00f"}); //azul
 
                   jQuery Widget factory
                 </h3>
-                <iframe src='http://wiki.jqueryui.com/w/page/12138135/Widget%20factory' style="margin:0"></iframe>
+                <iframe src='https://jqueryui.pbworks.com/w/page/12138135/Widget%20factory' style="margin:0"></iframe>
               </article>
     <article class='fill iframe-full'>
         <h3>
           jQuery Boilerplate
         </h3>
-        <iframe src='http://jqueryboilerplate.com/'style="margin:0"></iframe>
+        <iframe src='https://github.com/jquery-boilerplate'style="margin:0"></iframe>
 
       </article>
 
@@ -607,13 +607,13 @@ $("body").bgChange({bg: "#00f"}); //azul
                 </a>
             </li>
             <li class="black">
-                <a href="http://docs.jquery.com/Using_jQuery_with_Other_Libraries">
-                    http://docs.jquery.com/Using_jQuery_with_Other_Libraries
+                <a href="https://docs.jquery.com/Using_jQuery_with_Other_Libraries">
+                    https://docs.jquery.com/Using_jQuery_with_Other_Libraries
                 </a>
             </li>
             <li class="black">
-                <a href="https://jqueryboilerplate.com">
-                    https://jqueryboilerplate.com
+                <a href="https://github.com/jquery-boilerplate">
+                  https://github.com/jquery-boilerplate
                 </a>
             </li>
             <li class="black">


### PR DESCRIPTION
## Types of changes
- Bugfix

## Description of changes
- Migrate URLs to HTTPS in jqueryfn talk
