### PR TITLE
feat(nextjs): add trailing slash to the URLs to keep the same behavior from Gatsby

### DIFF
--- a/nextjs/next.config.js
+++ b/nextjs/next.config.js
@@ -1,5 +1,6 @@
 // next.config.js
 module.exports = {
+  trailingSlash: true,
   reactStrictMode: true,
   compiler: {
     styledComponents: true


### PR DESCRIPTION
## Types of changes
- Feature

## Description of changes
- Add trailing slash to the URLs to keep the same behavior from Gatsby