### PR TITLE
feat(talks): add icons to list items

### DIFF
--- a/components/list-item-link.js
+++ b/components/list-item-link.js
@@ -9,23 +9,21 @@ const HeadlineBase = styled.span`
   color: var(--color-gray);
   line-height: 1.25rem;
   padding: 2px 0;
-  margin-bottom: 5px;
+  margin-bottom: 0;
   vertical-align: top;
-
-  ${screen.md} {
-    margin-bottom: 0;
-  }
 `
 
 const Headline = styled(HeadlineBase)`
   margin-right: 0;
+  font-family: var(--font-title);
+  font-size: var(--font-size-xs);
 `
 
 const HeadlineSecondary = styled(HeadlineBase)`
   margin-left: 0.5rem;
 
   &:before {
-    content: '·';
+    content: '';
     margin-right: 0.5rem;
   }
 `

--- a/components/list-item-link.js
+++ b/components/list-item-link.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import styled from 'styled-components'
-import { screen } from '../styles/screen'
 
 const HeadlineBase = styled.span`
   display: inline-block;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:e2e": "CYPRESS_SUPPORT=y start-server-and-test develop http://localhost:3000 test:cy:open"
   },
   "dependencies": {
+    "@tabler/icons-react": "^3.34.1",
     "@vercel/analytics": "^1.0.1",
     "date-fns": "^2.30.0",
     "framer-motion": "^12.17.0",

--- a/pages/blog.js
+++ b/pages/blog.js
@@ -9,9 +9,17 @@ import PageTitle from '../components/page-title'
 import ListItemLink from '../components/list-item-link'
 import Seo from '../components/seo'
 import { formatDateToMonthDayYear } from '../lib/format-date-to-month-day-year'
+import { IconCalendar } from '@tabler/icons-react'
 
 const PostsWrapper = styled.div`
   margin-bottom: 15px;
+`
+
+const IconWrapper = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-right: 16px;
 `
 
 export default function Index({ posts }) {
@@ -55,7 +63,12 @@ const filterPostsByLang = (allPostsData, lang) => {
       <ListItemLink
         key={data.path}
         url={data.path}
-        headline={formatDateToMonthDayYear(data.date)}
+        headline={
+          <IconWrapper>
+            <IconCalendar size={14} />
+            {formatDateToMonthDayYear(data.date)}
+          </IconWrapper>
+        }
         headlineSecondary={''}
         title={data.title}
       />

--- a/pages/talks.js
+++ b/pages/talks.js
@@ -1,18 +1,53 @@
 import React from 'react'
+import styled from 'styled-components'
 import Seo from '../components/seo'
 import PageTitle from '../components/page-title'
 import Section from '../components/section'
 import ListItemLink from '../components/list-item-link'
 import Layout from '../components/layout'
+import { IconMapPin, IconPresentationAnalytics, IconCalendar } from '@tabler/icons-react'
 import talks from '../data/talks'
+
+const IconWrapper = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-right: 16px;
+`
+
+const DetailsContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin-top: 4px;
+
+  ${IconWrapper}:last-child {
+    margin-right: 0;
+  }
+`
 
 const formatAllTalks = () =>
   talks.map((talk, index) => (
     <ListItemLink
       url={talk.url}
       key={index}
-      headline={`${talk.where} - ${talk.city}`}
-      headlineSecondary={`${talk.date}`}
+      headline={
+        <DetailsContainer>
+          <IconWrapper>
+            <IconPresentationAnalytics size={14} />
+            {talk.where}
+          </IconWrapper>
+          <IconWrapper>
+            <IconMapPin size={14} />
+            {talk.city}
+          </IconWrapper>
+          <IconWrapper>
+            <IconCalendar size={14} />
+            {talk.date}
+          </IconWrapper>
+        </DetailsContainer>
+      }
       title={talk.title}
     />
   ))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@tabler/icons-react':
+        specifier: ^3.34.1
+        version: 3.34.1(react@19.1.0)
       '@vercel/analytics':
         specifier: ^1.0.1
         version: 1.5.0(next@15.3.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
@@ -385,6 +388,14 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@tabler/icons-react@3.34.1':
+    resolution: {integrity: sha512-Ld6g0NqOO05kyyHsfU8h787PdHBm7cFmOycQSIrGp45XcXYDuOK2Bs0VC4T2FWSKZ6bx5g04imfzazf/nqtk1A==}
+    peerDependencies:
+      react: '>= 16'
+
+  '@tabler/icons@3.34.1':
+    resolution: {integrity: sha512-9gTnUvd7Fd/DmQgr3MKY+oJLa1RfNsQo8c/ir3TJAWghOuZXodbtbVp0QBY2DxWuuvrSZFys0HEbv1CoiI5y6A==}
 
   '@textlint/ast-node-types@12.6.1':
     resolution: {integrity: sha512-uzlJ+ZsCAyJm+lBi7j0UeBbj+Oy6w/VWoGJ3iHRHE5eZ8Z4iK66mq+PG/spupmbllLtz77OJbY89BYqgFyjXmA==}
@@ -3956,6 +3967,13 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@tabler/icons-react@3.34.1(react@19.1.0)':
+    dependencies:
+      '@tabler/icons': 3.34.1
+      react: 19.1.0
+
+  '@tabler/icons@3.34.1': {}
 
   '@textlint/ast-node-types@12.6.1': {}
 

--- a/styles/variables.js
+++ b/styles/variables.js
@@ -27,4 +27,12 @@ export const variables = `
   --layout-wrapper-padding-sm: 16px;
   --layout-wrapper-padding-md: 24px;
   --layout-wrapper-padding-lg: 16px;
+
+  // Font sizes
+  --font-size-xs: 0.75rem;
+  --font-size-sm: 0.875rem;
+  --font-size-md: 1rem;
+  --font-size-lg: 1.25rem;
+  --font-size-xl: 1.5rem;
+  --font-size-xxl: 2rem;
 `


### PR DESCRIPTION
## Types of changes
- Feature

## Description of changes
- Adding calendar icons to blog post dates and talks
- Replacing bullet separators with proper icon
- Adding new font size variables

<img width="938" height="617" alt="Screenshot 2025-07-21 at 6 30 48 PM" src="https://github.com/user-attachments/assets/334ff054-8ef9-40c0-a043-2cb049d010c1" />
