### PR TITLE
fix(blog): align post date between listing and article page

### DIFF
--- a/lib/format-date-to-month-day-year.js
+++ b/lib/format-date-to-month-day-year.js
@@ -1,4 +1,16 @@
 export const formatDateToMonthDayYear = dateString => {
+  if (!dateString) {
+    return ''
+  }
+
+  // Date-only strings (YYYY-MM-DD) should be rendered as-is without
+  // timezone conversion to avoid day shifts in negative UTC offsets.
+  if (/^\d{4}-\d{2}-\d{2}$/.test(dateString)) {
+    const [year, month, day] = dateString.split('-').map(Number)
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+    return `${months[month - 1]} ${day}, ${year}`
+  }
+
   const options = { year: 'numeric', month: 'short', day: 'numeric' }
   return new Date(dateString).toLocaleDateString('en-US', options)
 }


### PR DESCRIPTION
## Summary
- avoid timezone conversion when rendering date-only (`YYYY-MM-DD`) values in blog listing cards
- keep the same calendar day display between `/blog` and the article page for migrated posts like "Moving WordPress to Jekyll"
- preserve existing formatting behavior for non date-only inputs

## Test plan
- [x] open `/blog` and confirm "Moving WordPress to Jekyll" date matches article page
- [x] verify date displays as `Apr 1, 2013` in listing and article
- [x] run lint diagnostics for touched files