### PR TITLE
fix(a11y): add aria-expanded to close menu button

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -257,7 +257,7 @@ const Header = () => {
 
       <MobileMenuOverlay $open={mobileMenuOpen} onClick={closeMobileMenu} aria-hidden="true" />
       <MobileMenuPanel $open={mobileMenuOpen}>
-        <MobileMenuClose onClick={closeMobileMenu} aria-label="Fechar menu">
+        <MobileMenuClose onClick={closeMobileMenu} aria-label="Fechar menu" aria-expanded={mobileMenuOpen}>
           <IconX size={24} stroke={1.5} />
         </MobileMenuClose>
         <MobileMenuLinks>

--- a/components/header.js
+++ b/components/header.js
@@ -257,7 +257,7 @@ const Header = () => {
 
       <MobileMenuOverlay $open={mobileMenuOpen} onClick={closeMobileMenu} aria-hidden="true" />
       <MobileMenuPanel $open={mobileMenuOpen}>
-        <MobileMenuClose onClick={closeMobileMenu} aria-label="Fechar menu" aria-expanded={mobileMenuOpen}>
+        <MobileMenuClose onClick={closeMobileMenu} aria-label="Close menu" aria-expanded={mobileMenuOpen}>
           <IconX size={24} stroke={1.5} />
         </MobileMenuClose>
         <MobileMenuLinks>


### PR DESCRIPTION
## Summary
- add `aria-expanded` to the mobile "Fechar menu" button
- keep assistive technology state reporting consistent with the "Abrir menu" button
- align mobile menu controls with expected accessibility semantics

## Test plan
- [x] inspect mobile header controls and confirm both open/close buttons expose `aria-expanded`
- [x] run lint diagnostics for `components/header.js`
- [x] verify no behavioral changes to menu open/close interactions