### PR TITLE
feat(observability): integrate Vercel Speed Insights

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@tabler/icons-react": "^3.34.1",
     "@vercel/analytics": "^1.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "date-fns": "^2.30.0",
     "framer-motion": "^12.17.0",
     "gray-matter": "^4.0.3",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,7 @@
 import Script from 'next/script'
 import { ThemeProvider } from 'styled-components'
 import { Analytics } from '@vercel/analytics/react'
+import { SpeedInsights } from '@vercel/speed-insights/next'
 
 const theme = {
   colors: {
@@ -16,6 +17,7 @@ export default function App({ Component, pageProps }) {
         <Component {...pageProps} />
       </ThemeProvider>
       <Analytics />
+      <SpeedInsights />
       <Script src="https://www.googletagmanager.com/gtag/js?id=G-EV10PWT7QL" />
       <Script id="google-analytics">
         {`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@vercel/analytics':
         specifier: ^1.0.1
         version: 1.5.0(next@16.1.1(@babel/core@7.28.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(next@16.1.1(@babel/core@7.28.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       date-fns:
         specifier: ^2.30.0
         version: 2.30.0
@@ -819,6 +822,32 @@ packages:
       '@sveltejs/kit':
         optional: true
       next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
         optional: true
       react:
         optional: true
@@ -4655,6 +4684,11 @@ snapshots:
     optional: true
 
   '@vercel/analytics@1.5.0(next@16.1.1(@babel/core@7.28.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+    optionalDependencies:
+      next: 16.1.1(@babel/core@7.28.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+
+  '@vercel/speed-insights@2.0.0(next@16.1.1(@babel/core@7.28.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
     optionalDependencies:
       next: 16.1.1(@babel/core@7.28.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0


### PR DESCRIPTION
## Summary
- install `@vercel/speed-insights` dependency
- add `SpeedInsights` to `pages/_app.js` so metrics are collected globally
- include lockfile updates from the package install

## Test plan
- [x] run lint diagnostics for modified app file
- [x] verify dependency and lockfile changes are present
- [ ] deploy and confirm Speed Insights events appear in Vercel dashboard