### PR TITLE
fix(seo): add canonical and twitter card meta tags

### DIFF
--- a/components/seo.js
+++ b/components/seo.js
@@ -1,13 +1,21 @@
 import Head from 'next/head'
+import { useRouter } from 'next/router'
 
 const Seo = ({ title, description = '' }) => {
+  const router = useRouter()
+  const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || process.env.SITE_URL || 'https://fellipe.com').replace(/\/$/, '')
+  const currentPath = (router.asPath || '/').split('?')[0].split('#')[0]
+  const canonicalUrl = `${siteUrl}${currentPath === '/' ? '' : currentPath}`
+
   return (
     <Head>
       <title>{`${title} | Davidson Fellipe`}</title>
       <meta name="description" content={description} />
+      <link rel="canonical" href={canonicalUrl} />
       <meta property="og:type" content="website" />
       <meta property="og:title" content={title} />
       <meta property="og:image" content="/images/profile.jpg" />
+      <meta name="twitter:card" content="summary_large_image" />
     </Head>
   )
 }


### PR DESCRIPTION
## Summary
- add canonical URL generation in `Seo` using the current route
- include `<link rel=\"canonical\">` across pages that use the shared SEO component
- add `twitter:card` metadata so X/Twitter can render rich previews

## Test plan
- [x] verify `components/seo.js` includes canonical and twitter card tags
- [x] confirm lint diagnostics for the updated file
- [ ] validate final rendered metadata in production HTML/head output