### PR TITLE
fix: hydration mismatch and duplicate nav links for screen readers

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -246,7 +246,7 @@ const Header = () => {
           <IconMenu2 size={28} stroke={1.5} />
         </HamburgerButton>
 
-        <Links>
+        <Links aria-hidden={mobileMenuOpen}>
           {navLinks.map(({ href, label }) => (
             <Link key={href} href={href}>
               {label}
@@ -256,11 +256,11 @@ const Header = () => {
       </Wrapper>
 
       <MobileMenuOverlay $open={mobileMenuOpen} onClick={closeMobileMenu} aria-hidden="true" />
-      <MobileMenuPanel $open={mobileMenuOpen}>
+      <MobileMenuPanel $open={mobileMenuOpen} aria-hidden={!mobileMenuOpen} inert={!mobileMenuOpen}>
         <MobileMenuClose onClick={closeMobileMenu} aria-label="Close menu" aria-expanded={mobileMenuOpen}>
           <IconX size={24} stroke={1.5} />
         </MobileMenuClose>
-        <MobileMenuLinks>
+        <MobileMenuLinks aria-hidden={!mobileMenuOpen}>
           {navLinks.map(({ href, label }) => (
             <Link key={href} href={href} onClick={closeMobileMenu}>
               {label}

--- a/components/seo.js
+++ b/components/seo.js
@@ -3,9 +3,10 @@ import { useRouter } from 'next/router'
 
 const Seo = ({ title, description = '' }) => {
   const router = useRouter()
-  const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || process.env.SITE_URL || 'https://fellipe.com').replace(/\/$/, '')
+  const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || 'https://fellipe.com').replace(/\/$/, '')
   const currentPath = (router.asPath || '/').split('?')[0].split('#')[0]
-  const canonicalUrl = `${siteUrl}${currentPath === '/' ? '' : currentPath}`
+  const normalizedPath = currentPath === '/' ? '' : currentPath.replace(/\/$/, '')
+  const canonicalUrl = `${siteUrl}${normalizedPath}`
 
   return (
     <Head>


### PR DESCRIPTION
## Summary
- fix canonical URL generation to avoid server/client divergence that can trigger hydration mismatch
- normalize canonical path output to avoid trailing slash inconsistencies
- hide inactive duplicate navigation link sets from assistive technologies in mobile/desktop menu states

## Test plan
- [x] verify `components/seo.js` canonical output logic is deterministic on SSR/CSR
- [x] verify inactive nav links are `aria-hidden` and mobile panel is inert when closed
- [x] run lint diagnostics for touched files