### PR TITLE
refactor: use internal links and enforce SITE_URL for sitemap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ temp/
 _posts_not_published/
 assets/themes/fellipecom/css/
 .DS_Store
-.env
 
 # IDE-specific files
 .vscode

--- a/content/analyzing-javascript-code-quality-using-jslint.md
+++ b/content/analyzing-javascript-code-quality-using-jslint.md
@@ -22,7 +22,7 @@ JSLint analyzes a given piece of code and identifies potential issues or syntax 
 [JSLint][6] is a powerful tool for everyday use by JavaScript programmers, as it demands greater precision in code writing for this language. It requires certain considerations, such as code indentation, line length, variable declaration, statements, and function declarations, among others. For example, the common JavaScript error mentioned in the article [Correct Usage of the parseInt Function in JavaScript][7] would be easily detected, and it would display the error "Missing radix parameter."
 
 [6]: https://www.jslint.com/
-[7]: https://fellipe.com/blog/uso-correto-da-funcao-do-parseint-em-javascript/
+[7]: /blog/uso-correto-da-funcao-do-parseint-em-javascript/
 
 Therefore, by using JSLint, you will be able to identify your most common errors and start adopting essential habits to become a better programmer in the JavaScript language. To use JSLint, simply access the website, paste your code, and click on the JSLint button. The good practice of always checking your code in this tool can even prevent cross-browser issues.
 

--- a/content/big-review-de-2012.md
+++ b/content/big-review-de-2012.md
@@ -11,7 +11,7 @@ tags: ["winter", "snow", "react"]
 
 Depois de ler alguns depoimentos de alguns amigos sobre 2012, resolvi escrever o meu. Esse ano, foi o ano que fez mais diferença na minha carreira profissional, e que ano! Comecei o ano visitando pela primeira vez a capital mineira, onde tive o prazer de palestrar no [BeagaJS][1], onde abordei o tema de [Performance em jQuery Apps][2]. Depois tirei férias… o/
 
-[1]: https://fellipe.com/blog/relato-sobre-o-beagajs/
+[1]: /blog/relato-sobre-o-beagajs/
 [2]: https://www.slideshare.net/davidsonfellipe/jqueryperf
 
 Nessas minhas primeiras férias, depois de 5 anos de faculdade e 1 ano e meio de Globo.com, resolvi conhecer o 2º destino turistíco mais visitado desse país, e o que eu tinha mais interesse em conhecer: Foz do Iguaçu, e ainda visitei, a Puerto Iguazú (Argentina) e Ciudad del Este (Paraguai), essa região de fronteiras é incrível e com muitas culturas diferentes, que se eu fosse contar todos os detalhes mereceria um post exclusivo.
@@ -28,7 +28,7 @@ Nada melhor que essa ultra-mega-hiper lotada Praça do Marco Zero, ao som de Seu
 
 Após voltar para o mundo real, tinha que começar a pensar no que eu poderia fazer de diferente em 2012, algo que pudesse ajudar a vida de muitas pessoas, então resolvi participar da organização de um evento para minha *terrinha* com grandes nomes da área do JavaScript, [junto com Luiz Tiago e Thiago Azurém criamos o PernambucoJS][5], com a grande colaboração de Djalma Araújo e Eduardo Lundgren.
 
-[5]: https://fellipe.com/blog/pernambucojs-2012-pre-evento/
+[5]: /blog/pernambucojs-2012-pre-evento/
 
 O [PernambucoJS][6] foi um projeto de cerca de 3 meses, onde levamos 7 palestrantes e contou com a presença de cerca de 220 pessoas. E ainda palestrei sobre[ JavaScript Cross-Browser][7].
 
@@ -47,7 +47,7 @@ Em Maio, fiquei na expectativa de minha primeira viagem internacional segunda v
 Depois da correria para visto e passaporte, embarquei com destino a San Francisco para participar da [Fluent Conferenc][10]e, a primeira conferência focada em JavaScript da O’Reilly, realizada na apaixonante San Francisco. Foram 3 dias de evento, e uma ótima oportunidade para troca ideias com desenvolvedores de várias partes do mundo, e abrir meus olhos para o grande crescimento do mercado de mobile para o desenvolvedor Frontend. Mais detalhes sobre o que rolou no evento podem ser conferidos nessa minha apresentação: [Fluent Conference Highlights][11], que apresentei em um TechTalk lá na Globo.com e também no Rio.js. Ainda pude conferir uma SF em clima de festa, em comemoração dos 75 anos da [Golden Gate Bridge][12], que trouxe um tempero especial para essa viagem.
 
 [10]: http://fluentconf.com
-[11]: https://fellipe.com/slides/fluent2012/pt/
+[11]: /slides/fluent2012/pt/
 [12]: https://www.youtube.com/watch?v=KPsXd28iuPc
 
 ## Preparativos para o Front in BH
@@ -115,7 +115,7 @@ Esse foi outro grande desafio para esse ano, onde busquei expor minha visão atu
 Já em agosto, rolou a BrazilJS Conference, um evento que superou todas minhas expectativas, e pela primeira vez reuniu a grande maioria da comunidade frontend do país, e grandes palestrantes do Brasil e do mundo, que também contou com forte apoio da [Globo.com][35], onde levamos um belo stand. Sem dúvida esse foi o momento “mais friozinho na barriga” do ano, subir num palco quase 1 mil pessoas presentes num teatro em Porto Alegre, não foi fácil e ao mesmo tempo foi o maior desafio para a timidez na minha vida! Fiz a primeira palestra do segundo dia do evento, com o tema [Performance em JavaScript][36].
 
 [35]: https://opensource.globo.com/
-[36]: https://fellipe.com/slides/performance-javascript/#1
+[36]: /slides/performance-javascript/#1
 
 Após ser anunciado e subir alguns degraus, vi aquela enorme platéia, bebi um gole de água, e falei para mim: “Vai lá e faz a melhor apresentação que você já fez na vida”, após uns 5 minutos tentando me entender com a forte iluminação, acredito que consegui passar a ideia para maioria dos presentes, e coletei feedbacks da apresentação, que já pude mostrá-los em um Workshop na Globo.com.
 

--- a/content/relato-sobre-o-frontinrio-2011.md
+++ b/content/relato-sobre-o-frontinrio-2011.md
@@ -14,7 +14,7 @@ category: reports
 
 No último sábado, 18, conforme [já citado por esse blog][2], aconteceu o FrontInRio 2011. Esse evento foi o primeiro com foco em desenvolvimento client-side em terras fluminenses. O evento que reuniu cerca de 170 inscritos, aconteceu na UniRio, no bairro da Urca e contou com 12 palestras de grandes nomes do cenário local. As palestras foram divididas em duas salas, cobrindo assuntos de nível básico ao avançando.
 
-[2]: https://fellipe.com/blog/front-in-rio-2011/
+[2]: /blog/front-in-rio-2011/
 
 O evento começou com as apresentações de **Maujor** e **André Fonseca**. A palestra do primeiro apresentou o tema @font-face e a do segundo foi sobre Testes unitários com javascript, usando o Jasmine.
 

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,4 +1,10 @@
-const SITE_URL = process.env.SITE_URL || 'https://fellipe.com';
+require('dotenv').config()
+
+const SITE_URL = process.env.SITE_URL
+
+if (!SITE_URL) {
+  throw new Error('SITE_URL is not defined. Please set it in your .env file.')
+}
  
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@vercel/analytics": "^1.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "date-fns": "^2.30.0",
+    "dotenv": "^17.4.2",
     "framer-motion": "^12.17.0",
     "gray-matter": "^4.0.3",
     "next": "^16.1.1",

--- a/pages/card.js
+++ b/pages/card.js
@@ -89,7 +89,7 @@ const CardPage = () => {
 
                   <QRCodeContainerTop>
                     <QRCode
-                      value="https://fellipe.com/card/"
+                      value="/card/"
                       size={120}
                       style={{ height: 'auto', maxWidth: '100%', width: '100%' }}
                       viewBox={`0 0 120 120`}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       date-fns:
         specifier: ^2.30.0
         version: 2.30.0
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       framer-motion:
         specifier: ^12.17.0
         version: 12.17.0(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1424,6 +1427,10 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -5305,6 +5312,8 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Replace legacy hardcoded `https://fellipe.com/...` internal references with site-relative URLs in selected content links and in the card QR code target.
- Update sitemap configuration to load environment variables via `dotenv` and fail fast when `SITE_URL` is missing.
- Add `dotenv` dependency and lockfile updates to support the sitemap config change.

## Test plan
- [x] Run `pnpm lint`
- [x] Run `pnpm build`
- [x] Run sitemap generation flow and confirm it errors when `SITE_URL` is unset
- [x] Run sitemap generation flow with `SITE_URL` set and confirm output URLs are correct