### PR TITLE
docs: add .env.example for required SITE_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+SITE_URL=


### PR DESCRIPTION
## Summary
- Add `.env.example` with `SITE_URL=` to document the required sitemap environment variable.
- Keep local `.env` untracked and out of version control.

## Test plan
- [x] Copy `.env.example` to `.env` and set `SITE_URL`
- [x] Run sitemap generation and confirm it succeeds with configured `SITE_URL`