### PR TITLE
fix(seo): redirect /index.html to home

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,7 @@
       {"source": "/lena-js/", "destination": "/demos/lena-js/", "statusCode": 301},
       {"source": "/articles/", "destination": "/blog", "statusCode": 301},
       {"source": "/docs/", "destination": "/", "statusCode": 301},
+      {"source": "/index.html", "destination": "/", "statusCode": 301},
       {"source": "/blog/brazil-js-2011/", "destination": "/blog/relato-sobre-o-braziljs-2011-fortaleza/", "statusCode": 301},
       {"source": "/blog/brazil-js-2011", "destination": "/blog/relato-sobre-o-braziljs-2011-fortaleza/", "statusCode": 301},
       {"source": "/blog/mercado-de-front-end-o-que-mudou-de-dois-anos-para-ca/", "destination": "/blog/front-end-market-in-2012-what-has-changed-in-the-past-two-years/", "statusCode": 301},


### PR DESCRIPTION
## Types of changes
- [x] fix

## Description of changes
Adds a 301 redirect from `/index.html` to `/` in `vercel.json`, matching the existing legacy URL redirect pattern.

Google Search Console reported 404s for `https://fellipe.com/index.html` and `https://www.fellipe.com/index.html` (legacy static-hosting paths). After deploy, crawlers and old links should resolve to the homepage.

## Test plan
- [x] Deploy to Vercel (or preview)
- [x] `curl -I https://fellipe.com/index.html` returns `301` with `Location: /`
- [x] Validate fix in Google Search Console after production deploy