### PR TITLE
fix(seo): align canonical URLs with trailing slashes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ pnpm textlint:fix
 
 ## Commits – Conventional Commits
 
-Always use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages:
+Commits and PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/) as used by [Commitizen](https://commitizen-tools.github.io/commitizen/). PR titles use the same format as commit subjects.
 
 ```
 <type>[optional scope]: <description>
@@ -87,6 +87,8 @@ pnpm exec cz
 ```
 
 ## Pull requests
+
+Use the same Conventional Commits format for the **PR title** as for commit subjects (see above).
 
 When creating or describing pull requests, use the `.github/PULL_REQUEST_TEMPLATE` format. Fill in:
 - **Types of changes** – e.g. feat, fix, docs, refactor

--- a/components/seo.js
+++ b/components/seo.js
@@ -5,7 +5,12 @@ const Seo = ({ title, description = '' }) => {
   const router = useRouter()
   const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || 'https://fellipe.com').replace(/\/$/, '')
   const currentPath = (router.asPath || '/').split('?')[0].split('#')[0]
-  const normalizedPath = currentPath === '/' ? '' : currentPath.replace(/\/$/, '')
+  const normalizedPath =
+    currentPath === '/' || currentPath === ''
+      ? ''
+      : currentPath.endsWith('/')
+        ? currentPath
+        : `${currentPath}/`
   const canonicalUrl = `${siteUrl}${normalizedPath}`
 
   return (


### PR DESCRIPTION
## Types of changes
- [x] fix
- [x] docs

## Description of changes
- **SEO:** Canonical URLs now keep trailing slashes to match `trailingSlash: true` in `next.config.js` (e.g. `https://fellipe.com/about/` instead of `/about`). Helps resolve “Discovered – currently not indexed” signals where Google found slash URLs but canonical pointed elsewhere.
- **Docs:** `AGENTS.md` documents Commitizen / Conventional Commits for commit messages and PR titles.

## Test plan
- [x] Deploy preview or production
- [x] View source on `/about/` — `<link rel="canonical" href="https://fellipe.com/about/" />`
- [x] `curl -sI https://fellipe.com/about/` returns `200`
- [x] Optional: URL Inspection → Request indexing for a few affected URLs in Search Console