### PR TITLE
fix(seo): use absolute Open Graph URLs and remove layout duplicates

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -16,8 +16,6 @@ export default function Layout({ children }) {
     <div>
       <Head>
         <link rel="icon" href="/favicon.ico" />
-        <meta name="og:title" content={siteTitle} />
-        <meta property="og:image" content="/images/profile.jpg" />
         <link href={profiles?.mastodon.url} rel="me" />
       </Head>
       <ResetStyles />

--- a/components/seo.js
+++ b/components/seo.js
@@ -12,16 +12,24 @@ const Seo = ({ title, description = '' }) => {
         ? currentPath
         : `${currentPath}/`
   const canonicalUrl = `${siteUrl}${normalizedPath}`
+  const ogImageUrl = `${siteUrl}/images/profile.jpg`
+  const ogTitle = `${title} | Davidson Fellipe`
 
   return (
     <Head>
-      <title>{`${title} | Davidson Fellipe`}</title>
+      <title>{ogTitle}</title>
       <meta name="description" content={description} />
       <link rel="canonical" href={canonicalUrl} />
       <meta property="og:type" content="website" />
-      <meta property="og:title" content={title} />
-      <meta property="og:image" content="/images/profile.jpg" />
+      <meta property="og:url" content={canonicalUrl} />
+      <meta property="og:title" content={ogTitle} />
+      {description ? (
+        <meta property="og:description" content={description} />
+      ) : null}
+      <meta property="og:image" content={ogImageUrl} />
       <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={ogTitle} />
+      <meta name="twitter:image" content={ogImageUrl} />
     </Head>
   )
 }


### PR DESCRIPTION
## Types of changes
- [x] fix

## Description of changes
- Use absolute URLs for Open Graph/Twitter preview images derived from `NEXT_PUBLIC_SITE_URL` (fallback production host).
- Add `og:url` matching the canonical link, optional `og:description`, and `twitter:title` / `twitter:image` for consistency with `summary_large_image`.
- Remove duplicate OG tags from `Layout` (`name="og:title"` and relative `og:image`) so page-level `Seo` is the single source of truth.

## Test plan
- [x] `pnpm lint`
- [x] View page source on a routed page (e.g. `/blog/`) and confirm `og:image`, `og:url`, `link rel="canonical"` share the same absolute origin when `NEXT_PUBLIC_SITE_URL` is set in preview/production.